### PR TITLE
normalize the start root path and fix mtime bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -300,7 +300,7 @@ FireWatch.start = function ( root, cb ) {
 
     Globby( [root, Path.join(root,'**/*')], function ( err, paths ) {
         paths.forEach( function ( path ) {
-            path = Path.normalize(path);
+            path = Path.normalize(path).replace(/\/$/, '');
             var stat = Fs.statSync(path);
             fireWatcher.files[path] = {
                 path: path,

--- a/test/test.js
+++ b/test/test.js
@@ -33,6 +33,21 @@ describe('FireWatch Simple Case', function () {
         reset();
     });
 
+    it('should work for the first argument which ends with slash', function ( done ) {
+        this.timeout(10000);
+        var tested = false;
+        var watcher = FireWatch.start(root + '/', function () {
+            watcher.stop( function () {
+                tested.should.eql(true);
+                done();
+            } );
+        });
+        watcher.on('changed', function ( results ) {
+            printResults(results);
+            tested = true;
+        });
+    });
+
     it('should work for new file', function ( done ) {
         this.timeout(10000);
         var tested = false;
@@ -354,6 +369,7 @@ describe('FireWatch Simple Case', function () {
             results.should.eql(expectResults);
         });
     });
+
 });
 
 describe('FireWatch Compound Case', function () {
@@ -404,7 +420,7 @@ describe('FireWatch Compound Case', function () {
         this.timeout(10000);
         var tested = false;
 
-        var watcher = FireWatch.start( root + '/', function () {
+        var watcher = FireWatch.start( root , function () {
             Fs.removeSync(Path.join(root, 'foo/foo-01'));
             Fs.removeSync(Path.join(root, 'bar'));
 

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,6 @@ function mapResults ( results ) {
 
 reset();
 var root = Fs.realpathSync('./test/foobar/');
-console.log(root);
 
 describe('FireWatch Simple Case', function () {
     beforeEach(function () {

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,7 @@ function mapResults ( results ) {
 
 reset();
 var root = Fs.realpathSync('./test/foobar/');
+console.log(root);
 
 describe('FireWatch Simple Case', function () {
     beforeEach(function () {
@@ -279,7 +280,9 @@ describe('FireWatch Simple Case', function () {
 
         var watcher = FireWatch.start( root, function () {
             Fs.removeSync( Path.join(root, 'foobar.js') );
-            Fs.copySync(Path.join(root, 'foobar.js.meta'), Path.join(root, 'foobar.js'));
+            Fs.copySync(Path.join(root, 'foobar.js.meta'), Path.join(root, 'foobar.js'), {
+                preserveTimestamps: false
+            });
 
             watcher.stop( function () {
                 tested.should.eql(true);
@@ -402,7 +405,7 @@ describe('FireWatch Compound Case', function () {
         this.timeout(10000);
         var tested = false;
 
-        var watcher = FireWatch.start( root, function () {
+        var watcher = FireWatch.start( root + '/', function () {
             Fs.removeSync(Path.join(root, 'foo/foo-01'));
             Fs.removeSync(Path.join(root, 'bar'));
 


### PR DESCRIPTION
该PR分别有两处更新：
1. 标准化了`start`函数的第一个路径参数，此前，当第一个参数为一个目录路径并且末尾是斜杠（/）时，会报错，我更新了一个单测例子来测试这种情况：https://github.com/yorkie/fire-watch/blob/normalize/input/test/test.js#L407
2. 通过设置`preserveTimestamps`为false来修正测试用例中关于`fsExtra.copySync`的用法。在`fs-extra`的[行26至28](https://github.com/jprichardson/node-fs-extra/blob/master/lib/copy-sync/copy-file-sync.js#L26-L28)中，如果`preserveTimestamps`设置为`true`（默认值），该模组也会自动地将`ctime`复制到`dest`所指定的文件。这也解释了为何我们单测中总是得到相同的`mtime`值的原因：

> 由于`preserveTimestamps`默认为`true`，所以我们总是从`foobar.js.meta`文件中拷贝`mtime`值并设置到新的`foobar.js`文件中，然后我们在测试过程中并未对`meta`文件进行任何更新（据我所看），因此`mtime`的值就总是一样的（甚至是在不同的单测中）。

需要注意的是，如果用户将`mtime`的值同样拷贝到`dest`中，我认为这种情况下，`fire-watch`不应该对其进行监听，不过是否可以将`preserveTimestamps`的默认值在`fire-fs`中改为`false`呢？

R= @jwu 
